### PR TITLE
Fix canvas pane layout to prevent scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,15 @@
 <style>
   :root { --bg:#f7f8fa; --panel:#ffffff; --line:#e5e7eb; --hover:#f0f3f8; --accent:#2563eb; }
   html,body { height:100%; margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; background:var(--bg); color:#1f2937; }
-  #wrap { display:flex; height:100%; }
+  body { overflow:hidden; }
+  #wrap { display:flex; height:100vh; }
 
   /* 左サイドバー */
   #sidebar {
     width:340px; max-width:42vw; min-width:270px;
     background:var(--panel); border-right:1px solid var(--line);
     display:flex; flex-direction:column; gap:14px; padding:14px; box-sizing:border-box;
+    overflow-y:auto;
   }
   #sidebar h2 { font-size:14px; margin:0 0 6px; color:#374151; }
   .section { padding:10px; border:1px solid var(--line); border-radius:12px; background:#fff; }
@@ -92,14 +94,15 @@
   .estimate-loan select { width:auto; min-width:110px; }
 
   /* 右側キャンバス */
-  #main { flex:1; display:flex; flex-direction:column; min-width:0; }
+  #main { flex:1; display:flex; flex-direction:column; min-width:0; position:relative; overflow:hidden; }
   #canvasPane { flex:1; position:relative; margin:12px; border:1px solid var(--line); border-radius:12px; background:#fff; }
   canvas { position:absolute; inset:0; width:100%; height:100%; display:block; background:#fff; touch-action:none; }
   #hint { position:absolute; right:10px; bottom:10px; background:#0007; color:#fff; font-size:12px; padding:6px 8px; border-radius:8px; }
 
   @media (max-width: 900px) {
-    #wrap { flex-direction:column; }
-    #sidebar { width:auto; max-width:none; border-right:none; border-bottom:1px solid var(--line); }
+    body { overflow:auto; }
+    #wrap { flex-direction:column; height:auto; }
+    #sidebar { width:auto; max-width:none; border-right:none; border-bottom:1px solid var(--line); overflow:visible; }
     #canvasPane { margin:10px; height:calc(100vh - 420px); }
   }
 </style>


### PR DESCRIPTION
## Summary
- keep the drawing canvas fixed to the viewport by preventing body scroll and locking the main container height
- allow the sidebar to scroll independently while keeping the canvas visible
- restore normal scrolling behavior on narrow layouts via responsive overrides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9d3bf7b50832f88acf8d25a43690f