### PR TITLE
Handle pointer capture failure on iPad pencil

### DIFF
--- a/index.html
+++ b/index.html
@@ -1332,6 +1332,7 @@ let selectedIdx=-1;
 let bgSelected=false;
 let drawing=false;
 let current=null;
+let pointerCaptureWorks=true;
 
 function hasActiveStrokes(){
   for (const entries of activeStrokes.values()){
@@ -1424,7 +1425,15 @@ function applyPinchTransform(mid, dist){
 }
 
 canvas.addEventListener('pointerdown',(e)=>{
-  e.preventDefault(); canvas.setPointerCapture(e.pointerId);
+  e.preventDefault();
+  if (pointerCaptureWorks && canvas.setPointerCapture){
+    try {
+      canvas.setPointerCapture(e.pointerId);
+    } catch (err){
+      pointerCaptureWorks=false;
+      console.warn('Pointer capture failed; continuing without capture.', err);
+    }
+  }
   const pt=getEventPoint(e); pointers.set(e.pointerId, pt);
   const pg=currentPage();
 


### PR DESCRIPTION
## Summary
- avoid aborting pointer handling when pointer capture is not supported (e.g., Apple Pencil)
- gracefully fall back without capture and log once when the browser throws

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9def6e954832f93efbd04694dd097