### PR TITLE
Restore detailed estimate editor layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,19 +36,32 @@
   .swatch { width:28px; height:28px; border-radius:7px; border:1px solid var(--line); cursor:pointer; }
   .swatch.active { outline:2px solid var(--accent); outline-offset:-2px; }
 
-  /* 見積 */
+  /* 見積書エディタ */
   #estimateEditor { display:none; }
+  #estimateEditor h2 { display:flex; justify-content:space-between; align-items:center; }
   #estimateRows { display:flex; flex-direction:column; gap:10px; margin-top:10px; }
   .estimate-row { display:grid; gap:10px; grid-template-columns:repeat(2, minmax(0, 1fr));
     align-items:flex-start; padding:12px; border:1px solid var(--line); border-radius:12px; background:#f9fafb; }
+  .estimate-row select, .estimate-row input { padding:6px 8px; }
+  .estimate-row select, .estimate-row input, .estimate-row textarea { width:100%; }
   .estimate-row .estimate-tooth { display:grid; grid-template-columns:repeat(3, minmax(0,1fr)); gap:6px; grid-column:1/-1; }
-  .estimate-row .estimate-note { grid-column:1/-1; min-height:52px; }
-  @media (max-width:600px){ .estimate-row { grid-template-columns:1fr; } }
+  .estimate-row .estimate-tooth select { min-width:0; }
+  .estimate-row .estimate-category,
+  .estimate-row .estimate-treatment,
+  .estimate-row .estimate-quantity,
+  .estimate-row .estimate-price { min-width:0; }
+  .estimate-row .estimate-note { grid-column:1/-1; min-width:0; min-height:52px; }
+  .estimate-row .estimate-remove { grid-column:2; justify-self:end; align-self:center; }
+  @media (max-width:600px){
+    .estimate-row { grid-template-columns:1fr; }
+    .estimate-row .estimate-remove { grid-column:auto; }
+  }
   .mini-btn { padding:6px 10px; font-size:12px; border-radius:8px; }
-  .estimate-summary { margin-top:14px; padding-top:10px; border-top:1px solid var(--line); display:flex; flex-direction:column; gap:6px; }
+  .estimate-summary { margin-top:14px; padding-top:10px; border-top:1px solid var(--line); display:flex; flex-direction:column;
+gap:6px; }
+  .estimate-summary strong { font-size:16px; }
   .estimate-loan { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
   .estimate-loan select { width:auto; min-width:110px; }
-
   /* 右側キャンバス */
   #main { flex:1; display:flex; flex-direction:column; min-width:0; position:relative; overflow:hidden; }
   #canvasPane { flex:1; position:relative; margin:12px; border:1px solid var(--line); border-radius:12px; background:#fff; touch-action:none; }
@@ -244,6 +257,57 @@ const TOOTH_SIDE_OPTIONS = ['', '右', '左'];
 const TOOTH_VERTICAL_OPTIONS = ['', '上', '下'];
 const TOOTH_NUMBER_OPTIONS = Array.from({length:8}, (_,i)=>String(i+1));
 const QUANTITY_OPTIONS = Array.from({length:99}, (_,i)=>i+1);
+
+const TREATMENT_GROUPS = [
+  {
+    id:'inlay', label:'インレー',
+    items:[
+      { id:'ceramic_inlay', label:'セラミックインレー', price:65000 },
+      { id:'zirconia_inlay', label:'ジルコニアインレー', price:70000 },
+      { id:'gold_inlay', label:'ゴールドインレー', price:100000 }
+    ]
+  },
+  {
+    id:'crown', label:'クラウン',
+    items:[
+      { id:'all_ceramic_crown', label:'オールセラミッククラウン', price:130000 },
+      { id:'zirconia_ceramic_crown', label:'ジルコニアセラミッククラウン', price:150000 },
+      { id:'full_zirconia_crown', label:'フルジルコニアクラウン', price:100000 },
+      { id:'metal_bond_crown', label:'メタルボンドクラウン', price:120000 },
+      { id:'gold_crown', label:'ゴールドクラウン', price:180000 }
+    ]
+  },
+  {
+    id:'denture', label:'入れ歯',
+    items:[
+      { id:'metal_base_denture', label:'金属床義歯', price:300000 },
+      { id:'non_clasp_crown', label:'ノンクラスプクラウン', price:100000 }
+    ]
+  },
+  {
+    id:'implant', label:'インプラント',
+    items:[
+      { id:'fixture', label:'フィクスチャー＋オペ料（検査費用含む）', price:275000 },
+      { id:'surgical_guide', label:'サージカルガイド', price:40000 },
+      { id:'provisional_restoration', label:'プロビジョナルレストレーション', price:100000 },
+      { id:'abutment_normal', label:'アバットメント（通常）', price:77000 },
+      { id:'abutment_on1', label:'アバットメント（On1）', price:88000 },
+      { id:'superstructure_zirconia', label:'上部構造（ジルコニアクラウン）', price:140000 },
+      { id:'gbr', label:'GBR（骨造成）', price:80000 },
+      { id:'socket_lift', label:'ソケットリフト', price:100000 },
+      { id:'sinus_lift', label:'サイナスリフト', price:150000 },
+      { id:'locator_abutment', label:'ロケーターアバットメント', price:100000 },
+      { id:'implant_overdenture', label:'インプラント オーバーデンチャー', price:400000 }
+    ]
+  },
+  {
+    id:'hygienist', label:'衛生士メニュー',
+    items:[
+      { id:'pmtc', label:'PMTC', price:13200 },
+      { id:'home_whitening', label:'ホームホワイトニング', price:33000 }
+    ]
+  }
+];
 
 /* ページデータ */
 function makeEstimateRow(){ return { tooth:'', category:'', treatment:'', unitPrice:0, price:0, quantity:1, note:'' }; }
@@ -959,7 +1023,7 @@ function makeCrownStamp(){ const w=260, h=220, off=document.createElement('canva
   g.fillStyle = 'rgba(0,0,0,0.06)'; g.beginPath(); g.ellipse(130,205,70,10,0,0,Math.PI*2); g.fill();
   const img=new Image(); img.src=off.toDataURL('image/png'); return img; }
 
-/* ========================= 見積エディタ（最小限：合計・月額反映） ========================= */
+/* ========================= 見積エディタ ========================= */
 const estimateEditorEl = document.getElementById('estimateEditor');
 const estimateRowsEl = document.getElementById('estimateRows');
 const estimateTotalDisplayEl = document.getElementById('estimateTotalDisplay');
@@ -967,78 +1031,382 @@ const estimateMonthlyDisplayEl = document.getElementById('estimateMonthlyDisplay
 const loanMonthsSelectEl = document.getElementById('loanMonthsSelect');
 const addEstimateRowBtn = document.getElementById('addEstimateRowBtn');
 
-function normalizeEstimateRow(row){ if (!row||typeof row!=='object') return makeEstimateRow();
-  row.tooth = typeof row.tooth==='string'?row.tooth:''; row.category=typeof row.category==='string'?row.category:''; row.treatment=typeof row.treatment==='string'?row.treatment:'';
-  const qty = parseInt(row.quantity,10); row.quantity = Math.min(99, Math.max(1, Number.isFinite(qty)?qty:1));
-  row.unitPrice = Number.isFinite(row.unitPrice)? row.unitPrice : Number(row.unitPrice)||0;
-  const priceNum = Number(row.price); row.price = Number.isFinite(priceNum)? priceNum : row.unitPrice * row.quantity;
-  row.note = typeof row.note==='string'?row.note:''; return row;
+function normalizeEstimateRow(row){
+  if (!row || typeof row !== 'object') return makeEstimateRow();
+  row.tooth = typeof row.tooth === 'string' ? row.tooth : '';
+  row.category = typeof row.category === 'string' ? row.category : '';
+  row.treatment = typeof row.treatment === 'string' ? row.treatment : '';
+  const qty = parseInt(row.quantity, 10);
+  row.quantity = Math.min(99, Math.max(1, Number.isFinite(qty) ? qty : 1));
+  row.unitPrice = Number.isFinite(row.unitPrice) ? row.unitPrice : Number(row.unitPrice) || 0;
+  const priceNum = Number(row.price);
+  row.price = Number.isFinite(priceNum) ? priceNum : row.unitPrice * row.quantity;
+  row.note = typeof row.note === 'string' ? row.note : '';
+  return row;
 }
-function ensureEstimateDataForPage(pg){ if (!pg.estimate) pg.estimate=makeEstimateData(); const est=pg.estimate;
-  if (!Array.isArray(est.rows)||est.rows.length===0) est.rows=[makeEstimateRow()];
-  est.rows = est.rows.map(r=>normalizeEstimateRow({...r}));
-  const months=parseInt(est.loanMonths,10); est.loanMonths=Math.min(60, Math.max(1, Number.isFinite(months)?months:12));
-  est.interestRate = Number.isFinite(est.interestRate)? est.interestRate : ESTIMATE_INTEREST_RATE; return est;
+
+function findTreatment(categoryId, treatmentId){
+  const group = TREATMENT_GROUPS.find(g=>g.id===categoryId) || null;
+  const item = group ? (group.items.find(it=>it.id===treatmentId) || null) : null;
+  return { group, item };
 }
-function getRowTotal(row){ const qty=Math.max(1, parseInt(row.quantity,10)||1); const base=Number(row.unitPrice)||0; return Math.round(base*qty || row.price||0); }
-function calculateEstimateTotal(est){ if (!est||!Array.isArray(est.rows)) return 0; return est.rows.reduce((s,r)=> s+getRowTotal(r), 0); }
-function calculateMonthlyPayment(amount, months, annualRate){ if (!months||months<=0||!amount) return 0; const principal=Math.max(0,amount); const r=annualRate>0? annualRate/12:0; if (r===0) return principal/months; return principal*r/(1-Math.pow(1+r,-months)); }
-function formatCurrency(n){ const v=Math.round(n||0); return `¥${currencyFormatter.format(v)}`; }
 
-function refreshEstimateEditor(){
-  const pg=currentPage();
-  if (!pg || pg.kind!=='estimate'){ estimateEditorEl.style.display='none'; return; }
-  const est = ensureEstimateDataForPage(pg);
-  estimateEditorEl.style.display='block';
+function getRowTotal(row){
+  const qty = Math.max(1, parseInt(row.quantity, 10) || 1);
+  if (typeof row.price === 'number' && !Number.isNaN(row.price)) return Math.round(row.price);
+  const base = Number(row.unitPrice) || 0;
+  return Math.round(base * qty);
+}
 
-  estimateRowsEl.innerHTML='';
-  est.rows.forEach((row, idx)=>{
-    const wrapper=document.createElement('div'); wrapper.className='estimate-row';
+function calculateEstimateTotal(est){
+  if (!est || !Array.isArray(est.rows)) return 0;
+  return est.rows.reduce((sum,row)=> sum + getRowTotal(row), 0);
+}
 
-    // 部位（簡易1フィールド）
-    const tooth=document.createElement('input'); tooth.type='text'; tooth.placeholder='部位（例：右上6）'; tooth.value=row.tooth||'';
-    tooth.oninput=()=>{ row.tooth=tooth.value; redraw(); };
-    wrapper.appendChild(tooth);
+function calculateMonthlyPayment(amount, months, annualRate){
+  if (!months || months <= 0 || !amount) return 0;
+  const principal = Math.max(0, amount);
+  const r = annualRate > 0 ? annualRate / 12 : 0;
+  if (r === 0) return principal / months;
+  return principal * r / (1 - Math.pow(1 + r, -months));
+}
 
-    // 内容
-    const treat=document.createElement('input'); treat.type='text'; treat.placeholder='治療内容'; treat.value=row.treatment||'';
-    treat.oninput=()=>{ row.treatment=treat.value; redraw(); };
-    wrapper.appendChild(treat);
+function formatCurrency(amount){
+  if (!amount) return '¥0';
+  const rounded = Math.round(amount);
+  return `¥${currencyFormatter.format(rounded)}`;
+}
 
-    // 個数
-    const qty=document.createElement('input'); qty.type='number'; qty.min='1'; qty.value=String(row.quantity||1);
-    qty.oninput=()=>{ const q=parseInt(qty.value,10)||1; row.quantity=Math.min(99,Math.max(1,q)); updateEstimateSummaryOnly(est); redraw(); };
-    wrapper.appendChild(qty);
+function ensureEstimateDataForPage(pg){
+  if (!pg) return null;
+  if (!pg.estimate) pg.estimate = makeEstimateData();
+  const est = pg.estimate;
+  if (!Array.isArray(est.rows)) est.rows = [makeEstimateRow()];
+  if (est.rows.length === 0) est.rows.push(makeEstimateRow());
+  for (let i=0;i<est.rows.length;i++) est.rows[i] = normalizeEstimateRow(est.rows[i]);
+  const months = parseInt(est.loanMonths, 10);
+  est.loanMonths = Math.min(60, Math.max(1, Number.isFinite(months) ? months : 12));
+  est.interestRate = Number.isFinite(est.interestRate) ? est.interestRate : ESTIMATE_INTEREST_RATE;
+  return est;
+}
 
-    // 単価
-    const unit=document.createElement('input'); unit.type='number'; unit.min='0'; unit.step='100'; unit.value=String(row.unitPrice||0);
-    unit.oninput=()=>{ row.unitPrice=Number(unit.value)||0; updateEstimateSummaryOnly(est); redraw(); };
-    wrapper.appendChild(unit);
+function serializeEstimate(est){
+  if (!est || !Array.isArray(est.rows)) return {
+    rows:[makeEstimateRow()],
+    loanMonths:12,
+    interestRate:ESTIMATE_INTEREST_RATE
+  };
+  return {
+    rows: est.rows.map(row=>{
+      const normalized = normalizeEstimateRow({...row});
+      return {
+        tooth: normalized.tooth || '',
+        category: normalized.category || '',
+        treatment: normalized.treatment || '',
+        quantity: normalized.quantity || 1,
+        unitPrice: Number(normalized.unitPrice) || 0,
+        price: Number(normalized.price) || 0,
+        note: normalized.note || ''
+      };
+    }),
+    loanMonths: Math.min(60, Math.max(1, parseInt(est.loanMonths, 10) || 12)),
+    interestRate: Number.isFinite(est.interestRate) ? est.interestRate : ESTIMATE_INTEREST_RATE
+  };
+}
 
-    // 備考
-    const note=document.createElement('textarea'); note.className='estimate-note'; note.placeholder='備考'; note.value=row.note||'';
-    note.oninput=()=>{ row.note=note.value; redraw(); };
-    wrapper.appendChild(note);
+function buildQuantityOptions(selectEl, value){
+  selectEl.innerHTML = '';
+  QUANTITY_OPTIONS.forEach(num=>{
+    const opt = document.createElement('option');
+    opt.value = String(num);
+    opt.textContent = `${num}`;
+    selectEl.appendChild(opt);
+  });
+  selectEl.value = String(value);
+}
 
-    // 削除
-    const del=document.createElement('button'); del.type='button'; del.className='mini-btn'; del.textContent='削除';
-    del.onclick=()=>{ if (est.rows.length<=1){ Object.assign(row, makeEstimateRow()); } else { est.rows.splice(idx,1); } refreshEstimateEditor(); redraw(); };
-    wrapper.appendChild(del);
+function ensureLoanOption(months){
+  if (!loanMonthsSelectEl) return;
+  const existing = Array.from(loanMonthsSelectEl.options).some(opt=>opt.value===String(months));
+  if (!existing){
+    const opt = document.createElement('option');
+    opt.value = String(months);
+    opt.textContent = `${months} 回`;
+    loanMonthsSelectEl.appendChild(opt);
+  }
+}
 
-    estimateRowsEl.appendChild(wrapper);
+function populateTreatmentOptions(selectEl, categoryId){
+  selectEl.innerHTML = '';
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '治療内容';
+  selectEl.appendChild(blank);
+  const group = TREATMENT_GROUPS.find(g=>g.id===categoryId);
+  if (group){
+    group.items.forEach(item=>{
+      const opt = document.createElement('option');
+      opt.value = item.id;
+      opt.textContent = item.label;
+      selectEl.appendChild(opt);
+    });
+  }
+}
+
+function parseToothValue(value){
+  const result = { side:'', arch:'', number:'' };
+  if (typeof value !== 'string') return result;
+  const match = value.match(/(右|左)(上|下)([1-8])/);
+  if (!match) return result;
+  result.side = match[1];
+  result.arch = match[2];
+  result.number = match[3];
+  return result;
+}
+
+function combineToothValue(side, arch, number){
+  const validSide = side === '右' || side === '左' ? side : '';
+  const validArch = arch === '上' || arch === '下' ? arch : '';
+  const numStr = TOOTH_NUMBER_OPTIONS.includes(String(number)) ? String(number) : '';
+  return (validSide && validArch && numStr) ? `${validSide}${validArch}${numStr}` : '';
+}
+
+function createEstimateRowElement(row, index, est){
+  const wrapper = document.createElement('div');
+  wrapper.className = 'estimate-row';
+
+  const toothWrapper = document.createElement('div');
+  toothWrapper.className = 'estimate-tooth';
+
+  const sideSelect = document.createElement('select');
+  const sidePlaceholder = document.createElement('option');
+  sidePlaceholder.value = '';
+  sidePlaceholder.textContent = '左右';
+  sideSelect.appendChild(sidePlaceholder);
+  TOOTH_SIDE_OPTIONS.filter(Boolean).forEach(label=>{
+    const opt = document.createElement('option');
+    opt.value = label;
+    opt.textContent = label;
+    sideSelect.appendChild(opt);
   });
 
-  if (loanMonthsSelectEl) loanMonthsSelectEl.value=String(est.loanMonths);
+  const archSelect = document.createElement('select');
+  const archPlaceholder = document.createElement('option');
+  archPlaceholder.value = '';
+  archPlaceholder.textContent = '上下';
+  archSelect.appendChild(archPlaceholder);
+  TOOTH_VERTICAL_OPTIONS.filter(Boolean).forEach(label=>{
+    const opt = document.createElement('option');
+    opt.value = label;
+    opt.textContent = label;
+    archSelect.appendChild(opt);
+  });
+
+  const numberSelect = document.createElement('select');
+  const numberPlaceholder = document.createElement('option');
+  numberPlaceholder.value = '';
+  numberPlaceholder.textContent = '1-8';
+  numberSelect.appendChild(numberPlaceholder);
+  TOOTH_NUMBER_OPTIONS.forEach(num=>{
+    const opt = document.createElement('option');
+    opt.value = num;
+    opt.textContent = num;
+    numberSelect.appendChild(opt);
+  });
+
+  const parsedTooth = parseToothValue(row.tooth || '');
+  sideSelect.value = parsedTooth.side || '';
+  archSelect.value = parsedTooth.arch || '';
+  numberSelect.value = parsedTooth.number || '';
+
+  toothWrapper.appendChild(sideSelect);
+  toothWrapper.appendChild(archSelect);
+  toothWrapper.appendChild(numberSelect);
+  wrapper.appendChild(toothWrapper);
+
+  const categorySelect = document.createElement('select');
+  categorySelect.classList.add('estimate-category');
+  const catBlank = document.createElement('option');
+  catBlank.value = '';
+  catBlank.textContent = '治療種類';
+  categorySelect.appendChild(catBlank);
+  TREATMENT_GROUPS.forEach(group=>{
+    const opt = document.createElement('option');
+    opt.value = group.id;
+    opt.textContent = group.label;
+    categorySelect.appendChild(opt);
+  });
+  categorySelect.value = row.category || '';
+  wrapper.appendChild(categorySelect);
+
+  const treatmentSelect = document.createElement('select');
+  treatmentSelect.classList.add('estimate-treatment');
+  populateTreatmentOptions(treatmentSelect, row.category);
+  treatmentSelect.value = row.treatment || '';
+  wrapper.appendChild(treatmentSelect);
+
+  const quantitySelect = document.createElement('select');
+  quantitySelect.classList.add('estimate-quantity');
+  buildQuantityOptions(quantitySelect, row.quantity || 1);
+  wrapper.appendChild(quantitySelect);
+
+  const priceInput = document.createElement('input');
+  priceInput.classList.add('estimate-price');
+  priceInput.type = 'number';
+  priceInput.min = '0';
+  priceInput.step = '100';
+  priceInput.value = String(Math.round(getRowTotal(row)) || 0);
+  wrapper.appendChild(priceInput);
+
+  const noteInput = document.createElement('textarea');
+  noteInput.className = 'estimate-note';
+  noteInput.placeholder = '備考';
+  noteInput.value = row.note || '';
+  wrapper.appendChild(noteInput);
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'mini-btn';
+  removeBtn.classList.add('estimate-remove');
+  removeBtn.textContent = '削除';
+  wrapper.appendChild(removeBtn);
+
+  const updateTooth = ()=>{
+    row.tooth = combineToothValue(sideSelect.value, archSelect.value, numberSelect.value);
+    redraw();
+  };
+
+  sideSelect.addEventListener('change', updateTooth);
+  archSelect.addEventListener('change', updateTooth);
+  numberSelect.addEventListener('change', updateTooth);
+
+  categorySelect.addEventListener('change', ()=>{
+    row.category = categorySelect.value;
+    row.treatment = '';
+    row.unitPrice = 0;
+    row.price = 0;
+    populateTreatmentOptions(treatmentSelect, row.category);
+    treatmentSelect.value = '';
+    priceInput.value = '0';
+    updateEstimateSummaryOnly(est);
+    redraw();
+  });
+
+  treatmentSelect.addEventListener('change', ()=>{
+    row.treatment = treatmentSelect.value;
+    const { item } = findTreatment(row.category, row.treatment);
+    if (item){
+      row.unitPrice = item.price;
+      row.price = item.price * row.quantity;
+    } else {
+      row.unitPrice = 0;
+      row.price = 0;
+    }
+    priceInput.value = String(Math.round(getRowTotal(row)) || 0);
+    updateEstimateSummaryOnly(est);
+    redraw();
+  });
+
+  quantitySelect.addEventListener('change', ()=>{
+    const prevQty = row.quantity || 1;
+    const newQty = Math.min(99, Math.max(1, parseInt(quantitySelect.value, 10) || 1));
+    let unit = row.unitPrice;
+    if ((!unit || unit <= 0) && row.price){
+      unit = row.price / prevQty;
+    }
+    row.quantity = newQty;
+    row.unitPrice = unit || 0;
+    row.price = (unit || 0) * newQty;
+    priceInput.value = String(Math.round(getRowTotal(row)) || 0);
+    updateEstimateSummaryOnly(est);
+    redraw();
+  });
+
+  priceInput.addEventListener('input', ()=>{
+    const val = Number(priceInput.value);
+    row.price = Number.isFinite(val) ? val : 0;
+    const qty = row.quantity || 1;
+    row.unitPrice = qty ? (row.price / qty) : row.price;
+    updateEstimateSummaryOnly(est);
+    redraw();
+  });
+
+  noteInput.addEventListener('input', ()=>{
+    row.note = noteInput.value;
+    redraw();
+  });
+
+  removeBtn.addEventListener('click', ()=>{
+    if (est.rows.length <= 1){
+      const blank = makeEstimateRow();
+      Object.assign(row, blank);
+    } else {
+      est.rows.splice(index, 1);
+    }
+    refreshEstimateEditor();
+    redraw();
+  });
+
+  return wrapper;
+}
+
+function updateEstimateSummaryOnly(est){
+  if (!est || !estimateTotalDisplayEl || !estimateMonthlyDisplayEl) return;
+  const total = calculateEstimateTotal(est);
+  estimateTotalDisplayEl.textContent = `合計（税込）：${formatCurrency(total)}`;
+  const monthly = calculateMonthlyPayment(total, est.loanMonths, est.interestRate || ESTIMATE_INTEREST_RATE);
+  estimateMonthlyDisplayEl.textContent = formatCurrency(monthly);
+}
+
+function refreshEstimateEditor(){
+  if (!estimateEditorEl || !estimateRowsEl || !estimateTotalDisplayEl || !estimateMonthlyDisplayEl) return;
+  const pg = currentPage();
+  if (!pg || pg.kind !== 'estimate'){
+    estimateEditorEl.style.display = 'none';
+    return;
+  }
+
+  const est = ensureEstimateDataForPage(pg);
+  estimateEditorEl.style.display = 'block';
+  ensureLoanOption(est.loanMonths);
+  if (loanMonthsSelectEl){
+    loanMonthsSelectEl.value = String(est.loanMonths);
+  }
+
+  estimateRowsEl.innerHTML = '';
+  est.rows.forEach((row, idx)=>{
+    estimateRowsEl.appendChild(createEstimateRowElement(row, idx, est));
+  });
+
   updateEstimateSummaryOnly(est);
 }
-function updateEstimateSummaryOnly(est){
-  const total = calculateEstimateTotal(est);
-  if (estimateTotalDisplayEl) estimateTotalDisplayEl.textContent = `合計（税込）：${formatCurrency(total)}`;
-  const monthly = calculateMonthlyPayment(total, est.loanMonths, est.interestRate||ESTIMATE_INTEREST_RATE);
-  if (estimateMonthlyDisplayEl) estimateMonthlyDisplayEl.textContent = formatCurrency(monthly);
+
+if (addEstimateRowBtn){
+  addEstimateRowBtn.addEventListener('click', ()=>{
+    const pg = currentPage();
+    if (!pg || pg.kind !== 'estimate'){
+      alert('見積書ページを選択してから行を追加してください。');
+      return;
+    }
+    const est = ensureEstimateDataForPage(pg);
+    est.rows.push(makeEstimateRow());
+    refreshEstimateEditor();
+    redraw();
+  });
 }
-if (addEstimateRowBtn){ addEstimateRowBtn.onclick=()=>{ const pg=currentPage(); if (!pg || pg.kind!=='estimate'){ alert('見積書ページを選択してください'); return; } const est=ensureEstimateDataForPage(pg); est.rows.push(makeEstimateRow()); refreshEstimateEditor(); redraw(); }; }
-if (loanMonthsSelectEl){ loanMonthsSelectEl.onchange=()=>{ const pg=currentPage(); if (!pg || pg.kind!=='estimate') return; const months = Math.min(60, Math.max(1, parseInt(loanMonthsSelectEl.value,10)||12)); pg.estimate.loanMonths=months; refreshEstimateEditor(); redraw(); }; }
+
+if (loanMonthsSelectEl){
+  loanMonthsSelectEl.addEventListener('change', ()=>{
+    const pg = currentPage();
+    if (!pg || pg.kind !== 'estimate') return;
+    const months = Math.min(60, Math.max(1, parseInt(loanMonthsSelectEl.value, 10) || 12));
+    pg.estimate.loanMonths = months;
+    loanMonthsSelectEl.value = String(months);
+    refreshEstimateEditor();
+    redraw();
+  });
+}
+
 
 /* ========================= 保存/読み込み ========================= */
 const PATIENT_EXPORT_VERSION = 2;
@@ -1057,7 +1425,7 @@ async function serializePatientData(){
     let bg=null; if (pg.bg){ const imageData=imageToDataURL(pg.bg.img); if (!imageData) missingImages=true;
       bg={ x:pg.bg.x, y:pg.bg.y, w:pg.bg.w, h:pg.bg.h, angle:pg.bg.angle||0, imageData }; }
     const pagePayload={ kind: pg.kind==='estimate' ? 'estimate' : 'blank', strokes, items, bg };
-    if (pg.kind==='estimate'){ const est=ensureEstimateDataForPage(pg); pagePayload.estimate = { rows: est.rows, loanMonths: est.loanMonths, interestRate: est.interestRate }; }
+    if (pg.kind==='estimate'){ const est=ensureEstimateDataForPage(pg); pagePayload.estimate = serializeEstimate(est); }
     serializedPages.push(pagePayload);
   }
   const payload={ version:PATIENT_EXPORT_VERSION, exportedAt:new Date().toISOString(), patient, showLines, view:{...view}, pages:serializedPages };


### PR DESCRIPTION
## Summary
- restore the detailed estimate editor layout styles so the grid, drop-downs, and summary fields match the previous detailed design
- reintroduce treatment metadata, selector logic, and detailed estimate row handling including loan option management
- ensure patient data export saves the normalized estimate payload structure for compatibility with the restored editor

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da32fb85d0832fbc6d55efae4e3c5f