### PR TITLE
Fix estimate page rendering regression

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,12 +577,12 @@ function drawEstimatePage(pg){
   const marginTop = baseVMargin + safe.top;
   const marginBottom = baseVMargin + safe.bottom;
   const availableWidth = logicalWidth - marginLeft - marginRight;
+  const invScale = 1 / view.scale;
   const innerPadding = 40 * invScale;
   const tableWidth = Math.max(0, availableWidth - innerPadding);
   if (tableWidth <= 0) return;
   const tableX = marginLeft + (availableWidth - tableWidth) / 2;
 
-  const invScale = 1 / view.scale;
   const headingFont = `${30 * invScale}px 'Noto Sans JP', system-ui, sans-serif`;
   const subHeadingFont = `${12 * invScale}px system-ui, sans-serif`;
   const bodyFontSize = 13;


### PR DESCRIPTION
## Summary
- define the estimate page scale factor before using it so the page renders again
- retain the reduced table width so the estimate table stays inside the frame margins

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da488da328832f923ba21305de4879