### PR TITLE
Adjust canvas pane padding for safe areas

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,20 @@ gap:6px; }
   .estimate-loan select { width:auto; min-width:110px; }
   /* 右側キャンバス */
   #main { flex:1; display:flex; flex-direction:column; min-width:0; position:relative; overflow:hidden; }
-  #canvasPane { flex:1; position:relative; margin:12px; border:1px solid var(--line); border-radius:12px; background:#fff; touch-action:none; }
+  #canvasPane {
+    flex:1;
+    position:relative;
+    margin:12px;
+    border:1px solid var(--line);
+    border-radius:12px;
+    background:#fff;
+    touch-action:none;
+    padding-top:max(0px, var(--safe-area-top));
+    padding-right:max(0px, var(--safe-area-right));
+    padding-bottom:max(0px, var(--safe-area-bottom));
+    padding-left:max(0px, var(--safe-area-left));
+    box-sizing:border-box;
+  }
   canvas { position:absolute; inset:0; width:100%; height:100%; display:block; background:#fff; touch-action:none; }
   #hint { position:absolute; right:10px; bottom:10px; background:#0007; color:#fff; font-size:12px; padding:6px 8px; border-radius:8px; pointer-events:none; }
 


### PR DESCRIPTION
## Summary
- add safe area padding around the canvas pane so treatment estimate details stay fully visible on devices with display insets

## Testing
- Manually opened http://127.0.0.1:8000/index.html in a browser


------
https://chatgpt.com/codex/tasks/task_e_68da690f5518832fa83f67b2a85e88b4